### PR TITLE
fix swapped argument names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Owa::Current.by_city("berlin")
 - To get the weather by geocode.
 
 ```ruby
-Owa::Current.by_geocode("130", "80")
+Owa::Current.by_geocode("80", "130")
 ```
 
 Note that on the events that API response is not a desired weather report this client raises errors with some messages which can be used to handle the error events and lets users know what went wrong.

--- a/lib/owa/base.rb
+++ b/lib/owa/base.rb
@@ -4,8 +4,8 @@ module Owa
       get_weather_with(Requests::Options::City.new(city, country_code, cnt))
     end
 
-    def self.by_geocode(lon, lat, cnt: nil)
-      get_weather_with(Requests::Options::Geocode.new(lon, lat, cnt))
+    def self.by_geocode(lat, lon, cnt: nil)
+      get_weather_with(Requests::Options::Geocode.new(lat, lon, cnt))
     end
 
     def self.by_zip(zip, country_code: nil, cnt: nil)

--- a/lib/owa/version.rb
+++ b/lib/owa/version.rb
@@ -1,3 +1,3 @@
 module Owa
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
note that the code in the request wants [lat then lon](https://github.com/homechef/owa/blob/master/lib/owa/requests/options/geocode.rb#L5), so this is just a naming problem in the updated file causing confusion to users.
